### PR TITLE
Editing the BaselineOfToplo to resolve conflict with baselineOfPyramid

### DIFF
--- a/src/BaselineOfToplo/BaselineOfToplo.class.st
+++ b/src/BaselineOfToplo/BaselineOfToplo.class.st
@@ -28,11 +28,11 @@ BaselineOfToplo >> dependencies: spec [
 
 	spec
 		baseline: 'Bloc'
-		with: [ spec repository: 'github://pharo-graphics/Bloc:master/src' ].
+		with: [ spec repository: 'github://OpenSmock/Bloc:dev/src' ].
 
 	spec
 		baseline: 'Album'
-		with: [ spec repository: 'github://pharo-graphics/Album:master/src' ]
+		with: [ spec repository: 'github://OpenSmock/Album:master/src' ]
 ]
 
 { #category : #baselines }


### PR DESCRIPTION
Editing the BaselineOfToplo to take the dependencies of Bloc and Album from OpenSmock instead of pharo-graphics